### PR TITLE
fix website link

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -6,7 +6,7 @@ license=Perl_5
 copyright_holder=Steven Haryanto
 
 [MetaResources]
-homepage=http://metacpan.org/dist/Data-Unixish
+homepage=https://metacpan.org/release/Data-Unixish
 repository=http://github.com/sharyanto/perl-Data-Unixish
 
 [@SHARYANTO]


### PR DESCRIPTION
/dist/ is for search.cpan.org. metacpan uses /release/
